### PR TITLE
feat: Reposition chat support to left with homepage popup greeting

### DIFF
--- a/components/ChatButton.tsx
+++ b/components/ChatButton.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { MessageCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 declare global {
   interface Window {
@@ -11,9 +13,14 @@ declare global {
 interface ChatButtonProps {
   className?: string;
   children?: React.ReactNode;
+  showIcon?: boolean;
 }
 
-export default function ChatButton({ className = '', children = 'Chat with us' }: ChatButtonProps) {
+export default function ChatButton({
+  className = '',
+  children,
+  showIcon = true
+}: ChatButtonProps) {
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
@@ -40,9 +47,21 @@ export default function ChatButton({ className = '', children = 'Chat with us' }
 
   return (
     <button
-      className={`open-zammad-chat ${className}`}
       onClick={handleClick}
+      className={cn(
+        'fixed bottom-6 left-6 z-50',
+        'p-3 rounded-full',
+        'bg-vln-sage/90 hover:bg-vln-sage',
+        'text-vln-bg',
+        'shadow-lg hover:shadow-xl',
+        'transition-all duration-300',
+        'glow-lift',
+        'hover:scale-110',
+        className
+      )}
+      aria-label="Open chat support"
     >
+      {showIcon && <MessageCircle className="w-5 h-5 sm:w-6 sm:h-6" />}
       {children}
     </button>
   );

--- a/components/ChatPopupGreeting.tsx
+++ b/components/ChatPopupGreeting.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { X, MessageCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+declare global {
+  interface Window {
+    zammadChatOpen?: () => void;
+  }
+}
+
+interface ChatPopupGreetingProps {
+  autoShowDelay?: number;
+}
+
+export default function ChatPopupGreeting({ autoShowDelay = 2000 }: ChatPopupGreetingProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    // Check if user has already dismissed the popup in this session
+    const dismissed = sessionStorage.getItem('chat-popup-dismissed');
+    if (dismissed) {
+      setIsDismissed(true);
+      return;
+    }
+
+    // Check if Zammad is loaded
+    const checkZammad = setInterval(() => {
+      if (window.zammadChatOpen) {
+        setIsReady(true);
+        clearInterval(checkZammad);
+      }
+    }, 100);
+
+    // Show popup after delay
+    const timer = setTimeout(() => {
+      if (!dismissed) {
+        setIsVisible(true);
+      }
+    }, autoShowDelay);
+
+    return () => {
+      clearInterval(checkZammad);
+      clearTimeout(timer);
+    };
+  }, [autoShowDelay]);
+
+  const handleStartChat = () => {
+    if (window.zammadChatOpen) {
+      window.zammadChatOpen();
+      handleDismiss();
+    }
+  };
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    setIsDismissed(true);
+    sessionStorage.setItem('chat-popup-dismissed', 'true');
+  };
+
+  if (isDismissed || !isReady) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'fixed z-40',
+        // Mobile & Tablet: above chat button, left side
+        'bottom-20 left-6',
+        // Desktop: to the right of chat button
+        'md:bottom-6 md:left-24',
+        'transition-all duration-500 ease-out',
+        isVisible
+          ? 'opacity-100 translate-y-0'
+          : 'opacity-0 translate-y-4 pointer-events-none'
+      )}
+    >
+      <div className="bg-vln-bg-light border border-vln-sage/30 rounded-lg shadow-2xl max-w-sm overflow-hidden">
+        {/* Header with gradient */}
+        <div className="bg-gradient-to-r from-vln-sage/20 to-vln-bg-light border-b border-vln-sage/30 px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <MessageCircle className="w-5 h-5 text-vln-sage" />
+            <h3 className="text-vln-white font-semibold text-sm">Welcome to VLN Security!</h3>
+          </div>
+          <button
+            onClick={handleDismiss}
+            className="text-vln-gray hover:text-vln-white transition-colors p-1 hover:bg-vln-bg-lighter rounded"
+            aria-label="Close popup"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-4 space-y-3">
+          <p className="text-vln-gray text-sm">
+            Hi! Need help securing your smart contracts?
+          </p>
+
+          <ul className="space-y-2 text-sm text-vln-gray">
+            <li className="flex items-start gap-2">
+              <span className="text-vln-sage mt-0.5">•</span>
+              <span>Smart Contract Audits</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-vln-sage mt-0.5">•</span>
+              <span>Vulnerability Research</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-vln-sage mt-0.5">•</span>
+              <span>24/7 Incident Response</span>
+            </li>
+          </ul>
+
+          <button
+            onClick={handleStartChat}
+            className={cn(
+              'w-full py-2.5 px-4 rounded-lg',
+              'bg-vln-sage hover:bg-vln-sage-light',
+              'text-vln-bg font-semibold text-sm',
+              'transition-all duration-300',
+              'glow-lift',
+              'hover:shadow-vln-glow',
+              'flex items-center justify-center gap-2'
+            )}
+          >
+            Start Chat
+            <span className="text-lg">→</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ZammadWidgetWrapper.tsx
+++ b/components/ZammadWidgetWrapper.tsx
@@ -2,12 +2,25 @@
 
 import { usePathname } from 'next/navigation';
 import ZammadWidget from './ZammadWidget';
+import ChatButton from './ChatButton';
+import ChatPopupGreeting from './ChatPopupGreeting';
 
 export default function ZammadWidgetWrapper() {
   const pathname = usePathname();
 
-  // Auto-show only on homepage
+  // Auto-show popup greeting only on homepage
   const isHomePage = pathname === '/';
 
-  return <ZammadWidget show={isHomePage} />;
+  return (
+    <>
+      {/* Zammad widget initialization - hidden by default */}
+      <ZammadWidget show={false} />
+
+      {/* Chat button - always visible on left side */}
+      <ChatButton />
+
+      {/* Popup greeting - only on homepage */}
+      {isHomePage && <ChatPopupGreeting />}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

Redesigns the chat widget positioning and behavior to improve UX and avoid conflicts with existing UI elements:

- **Chat button moved to left side** (bottom-left) to avoid conflict with ScrollToTop button on right
- **New ChatPopupGreeting component** appears only on homepage after 2s delay
- **Responsive positioning** across all breakpoints (mobile, tablet, desktop, widescreen)
- **Session-based dismissal** prevents popup re-appearance after user closes it

## Changes

### Components Modified
- `ChatButton.tsx`: Repositioned to bottom-left with sage green styling, MessageCircle icon
- `ZammadWidgetWrapper.tsx`: Now orchestrates both button and conditional popup

### Components Added
- `ChatPopupGreeting.tsx`: Homepage-only greeting popup with auto-show and dismissal

## Design Rationale

1. **Left positioning for chat**: Follows industry standard for chat widgets
2. **Separates UI elements**: Chat (left) vs Navigation/ScrollToTop (right)
3. **Homepage engagement**: Popup greeting increases initial visitor engagement
4. **Other pages**: Button-only approach respects user browsing intent

## Mockup Reference

Based on approved ASCII mockups:
- **Set A (Homepage)**: Chat button + popup greeting on left, ScrollToTop on right
- **Set B (Other pages)**: Chat button only on left, ScrollToTop on right

## Test Plan

- [ ] Homepage displays popup greeting after 2s delay
- [ ] Popup can be dismissed and doesn't reappear (session storage)
- [ ] Chat button opens Zammad widget correctly
- [ ] All other pages show only chat button (no popup)
- [ ] Responsive behavior works across mobile, tablet, desktop, widescreen
- [ ] No overlap with ScrollToTop button
- [ ] Build passes without errors

## Visual Preview

**Homepage (with popup):**
```
Bottom-left: Chat button + Popup greeting
Bottom-right: ScrollToTop button
```

**Other pages (no popup):**
```
Bottom-left: Chat button only
Bottom-right: ScrollToTop button
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)