### PR TITLE
fix(ci): import GitHub GPG keys for merge commit verification

### DIFF
--- a/.github/workflows/verify-signatures.yml
+++ b/.github/workflows/verify-signatures.yml
@@ -58,6 +58,11 @@ jobs:
 
       - name: Import Trusted GPG Keys
         run: |
+          # Import GitHub's official GPG signing key for merge commits
+          echo "Importing GitHub's GPG signing keys..."
+          curl -sL https://github.com/web-flow.gpg | gpg --import || true
+          echo "GitHub GPG keys imported"
+
           # Import organization GPG keys (skip silently if secrets not configured)
           if [ -n "${{ secrets.VLN_GPG_PUBLIC_KEY }}" ]; then
             echo "${{ secrets.VLN_GPG_PUBLIC_KEY }}" | gpg --import || true
@@ -193,7 +198,7 @@ jobs:
           echo "Author: $AUTHOR_NAME <$AUTHOR_EMAIL>"
 
           # Check if author is in approved list
-          APPROVED_DOMAINS=("@vln.gg" "@fusedgaming.io" "@users.noreply.github.com" "@anthropic.com")
+          APPROVED_DOMAINS=("@vln.gg" "@fusedgaming.io" "@users.noreply.github.com" "@anthropic.com" "@github.com")
           IS_APPROVED=false
 
           for domain in "${APPROVED_DOMAINS[@]}"; do


### PR DESCRIPTION
Fixed failing verify-signatures.yml workflow by importing GitHub's official GPG signing keys. GitHub-created merge commits are signed with GitHub's GPG key (web-flow), which was not being imported, causing signature verification to fail.

Changes:
- Import GitHub's GPG keys from https://github.com/web-flow.gpg
- Add @github.com to approved author domains for GitHub merge commits
- This allows verification of GitHub-signed merge commits (e.g., PR merges)

Resolves failing workflow runs #43, #44, #45 on development and main branches.

https://claude.ai/code/session_015H3gaoZYd8hL3rsi1hWVgS
