### PR TITLE
Add root package to pnpm workspace packages list

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 ignoredBuiltDependencies:
   - esbuild
   - sharp


### PR DESCRIPTION
## Summary
Updated the pnpm workspace configuration to explicitly include the root package in the workspace packages list.

## Changes
- Added `packages:` section to `pnpm-workspace.yaml`
- Configured root directory (`'.'`) as a workspace package

## Details
This change makes the root package an explicit member of the pnpm workspace. This ensures the root package is properly recognized and managed as part of the monorepo structure, which can improve dependency resolution and workspace commands behavior.

https://claude.ai/code/session_01UTJqDvY1rp6MuakN36ZcfS