### PR TITLE
fix(nav): resolve VLN logo bottom cutoff in navigation

### DIFF
--- a/public/vln-logo-dark.svg
+++ b/public/vln-logo-dark.svg
@@ -1,4 +1,4 @@
-<svg width="480" height="140" viewBox="0 0 480 140" xmlns="http://www.w3.org/2000/svg">
+<svg width="480" height="150" viewBox="0 0 480 150" xmlns="http://www.w3.org/2000/svg">
   <!-- VLN.gg Logo - Dark Variant (for dark backgrounds) -->
   <!-- Brand Colors: Sage Green #a6c3a7, Warm Blue-Gray #aab7c8, Matte Charcoal #0f0f0f -->
 


### PR DESCRIPTION
The SVG viewBox height was 140 but the shield path extended to y=145 (group translated by 20 + shield path ending at y=125). Increased the SVG height and viewBox to 150 so the full shield is visible.

Closes #43

https://claude.ai/code/session_01VB5R2DaeoMVmRpLZ5BeLXo