### PR TITLE
fix(ci): resolve cache path error, broken lint, and missing artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         continue-on-error: true
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: 📦 Setup Node.js
         if: steps.check_package.outputs.has_package == 'true'
@@ -64,7 +64,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: 🔍 pnpm Audit
         if: steps.check_package.outputs.has_package == 'true'
@@ -99,7 +98,7 @@ jobs:
         if: steps.check_package.outputs.has_package == 'true'
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: 📦 Setup Node.js
         if: steps.check_package.outputs.has_package == 'true'
@@ -119,7 +118,7 @@ jobs:
 
       - name: 🔍 Type Check
         if: steps.check_package.outputs.has_package == 'true'
-        run: pnpm tsc --noEmit
+        run: pnpm exec tsc --noEmit
 
   build-and-test:
     name: 🔨 Build & Test
@@ -145,7 +144,7 @@ jobs:
         if: steps.check_package.outputs.has_package == 'true'
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: 📦 Setup Node.js
         if: steps.check_package.outputs.has_package == 'true'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
     "test": "vitest",
     "test:widget": "vitest __tests__/ZammadWidget.test.tsx",
     "test:widget:ui": "vitest __tests__/ZammadWidget.test.tsx --ui",


### PR DESCRIPTION
Three issues reported in #45:

1. Security-audit cache validation error: removed `cache: 'pnpm'` from the setup-node step in the security-audit job since pnpm install never runs there, leaving the pnpm store empty and causing the cache save to fail.

2. Lint & Type Check exit code 1: `next lint` was removed as a CLI command in Next.js 16. Updated `package.json` lint script to use `ESLINT_USE_FLAT_CONFIG=false eslint .` (ESLint 9 with legacy config compatibility). Also changed `pnpm tsc` to `pnpm exec tsc` for explicit binary invocation.

3. Build & Test missing .next/ artifacts: updated all pnpm/action-setup steps from version 9 to version 10 to match the pnpm version used locally when the lockfile was generated, ensuring `--frozen-lockfile` installs correctly.

https://claude.ai/code/session_019mYsyWgU9HbgB1UaDtgxgE