### PR TITLE
feat(analytics): add GA4 tag G-YGDJT8YMYX alongside GTM

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -290,6 +290,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           }}
         />
         {/* End Google Tag Manager */}
+        {/* Google Analytics 4 */}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-YGDJT8YMYX" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-YGDJT8YMYX');`,
+          }}
+        />
+        {/* End Google Analytics 4 */}
       </head>
       <body className="antialiased bg-vln-bg text-vln-white font-sans">
         {/* Google Tag Manager (noscript) */}


### PR DESCRIPTION
Adds direct Google Analytics 4 measurement ID (G-YGDJT8YMYX) via gtag.js inline script, running in parallel with the existing GTM-TQLNNHSS container.