### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/components/ClaudiaWidget.tsx
+++ b/components/ClaudiaWidget.tsx
@@ -20,6 +20,23 @@ interface QAPair {
   keywords: string[];
 }
 
+// Safely format message content for HTML rendering:
+// 1. Escape HTML meta-characters to prevent XSS.
+// 2. Convert newlines to <br />.
+// 3. Wrap backticked text in <code> tags.
+function formatMessageContent(content: string): string {
+  const escaped = content
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+  return escaped
+    .replace(/\n/g, '<br />')
+    .replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
 const predefinedQA: QAPair[] = [
   {
     question: "How do I prevent SSRF attacks?",
@@ -509,7 +526,7 @@ Would you like to rephrase your question or [Ask Claude directly](https://claude
                 <div key={idx} className={`${styles.message} ${styles[message.role]}`}>
                   <div className={styles.messageContent}>
                     {message.role === 'assistant' ? (
-                      <div dangerouslySetInnerHTML={{ __html: message.content.replace(/\n/g, '<br />').replace(/`([^`]+)`/g, '<code>$1</code>') }} />
+                      <div dangerouslySetInnerHTML={{ __html: formatMessageContent(message.content) }} />
                     ) : (
                       message.content
                     )}


### PR DESCRIPTION
Potential fix for [https://github.com/Fused-Gaming/vln/security/code-scanning/3](https://github.com/Fused-Gaming/vln/security/code-scanning/3)

In general, the fix is to ensure that any untrusted text is safely encoded or sanitized before being rendered as HTML, especially when using `dangerouslySetInnerHTML`. Since you need simple formatting (line breaks and backticked code) but not arbitrary HTML from users, the best approach is: (1) escape all HTML meta‑characters in the text, then (2) apply your markdown-like formatting on that escaped string, and then render the result. This preserves your existing behavior for predefined answers but prevents user‑supplied HTML from being executed.

The minimal change within this file is to introduce a small helper that converts a plain text string into safe HTML by first escaping `&`, `<`, `>`, `"`, and `'`, then replacing `\n` with `<br />` and backticked segments with `<code>…</code>`. Then, instead of calling `.replace` directly on `message.content` in the JSX, call this new helper. This keeps functionality (line breaks and inline code styling) intact while preventing script injection.

Concretely:

- Add a helper function near the top of `ClaudiaWidget` (or just above it) in `components/ClaudiaWidget.tsx`, for example `formatMessageContent(content: string): string`, which:
  - Escapes HTML meta‑characters.
  - Replaces newline characters with `<br />`.
  - Wraps backticked segments in `<code>` tags on the *escaped* text.
- Update line 512 so that `dangerouslySetInnerHTML` uses `formatMessageContent(message.content)` instead of performing `.replace()` inline.

No new external libraries are strictly necessary; a small, explicit escape function in this file suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
