### PR TITLE
Exclude design-site from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
   ],
   "exclude": [
     "node_modules",
-    "docs-site"
+    "docs-site",
+    "design-site"
   ]
 }


### PR DESCRIPTION
## Summary
Updated the TypeScript configuration to exclude the `design-site` directory from compilation, alongside the existing `docs-site` exclusion.

## Changes
- Added `design-site` to the `exclude` array in `tsconfig.json`

## Details
This change prevents TypeScript from processing files in the `design-site` directory during compilation, which is consistent with the existing exclusion of the `docs-site` directory. This is typically done for documentation or design system sites that don't need to be type-checked as part of the main project's build process.

https://claude.ai/code/session_013c19XyZzm9BkyvAfWxUu4N