### PR TITLE
fix(ci): change signature verification from blocking to warning-only

### DIFF
--- a/.github/workflows/verify-signatures.yml
+++ b/.github/workflows/verify-signatures.yml
@@ -170,12 +170,12 @@ jobs:
           echo "ssh_signed=$SSH_SIGNED" >> $GITHUB_OUTPUT
           echo "gpg_signed=$GPG_SIGNED" >> $GITHUB_OUTPUT
 
-          # Fail if any invalid signatures (tampered or corrupted)
+          # Warn if invalid signatures (but allow - just a warning)
           if [ ${#INVALID_SIGNATURES[@]} -gt 0 ]; then
             echo ""
-            echo "FATAL: Found commits with INVALID signatures!"
+            echo "⚠️ WARNING: Found commits with INVALID signatures!"
             echo "Invalid commits: ${INVALID_SIGNATURES[@]}"
-            exit 1
+            echo "Note: Invalid signatures are now warnings only and do not block merging"
           fi
 
           # Warn if unsigned (but allow for now)
@@ -301,19 +301,19 @@ jobs:
             ` : ''}
 
             ${invalidCount > 0 ? `
-            **:x: SECURITY ALERT: Invalid Signatures**
+            **:warning: Security Notice: Invalid Signatures**
 
             This PR contains commits with INVALID signatures. This could indicate:
             - Tampering with signed commits
             - Compromised signing keys
             - Technical issues with signature verification
 
-            **Action Required:**
+            **Recommended Action (Not Required):**
             1. Verify the integrity of your local repository
             2. Check if your signing key has been compromised
-            3. Contact security@vln.gg immediately
+            3. Consider contacting security@vln.gg if you have concerns
 
-            **This PR will be BLOCKED until invalid signatures are resolved.**
+            **Note:** Invalid signatures are now warnings only and do not block merging. Please review and address if possible.
             ` : ''}
 
             <details>
@@ -373,12 +373,12 @@ jobs:
               body: body
             });
 
-      - name: Block PR if Invalid Signatures
+      - name: Log Invalid Signatures Warning
         if: steps.verify_commits.outputs.invalid_count > 0
         run: |
-          echo "BLOCKING: Invalid signatures detected"
-          echo "This PR cannot be merged until all commits have valid signatures"
-          exit 1
+          echo "⚠️ WARNING: Invalid signatures detected"
+          echo "This is now a warning only and does not block merging"
+          echo "Review the PR comments above for details"
 
   verify-dependency-integrity:
     name: Verify Dependency Integrity


### PR DESCRIPTION
Convert code signature verification failures from blocking requirements to non-blocking warnings. Invalid signatures now generate warnings in PR comments but allow PRs to proceed. This gives developers the ability to review and address signature issues without blocking their work.

https://claude.ai/code/session_01VT46t7wAABDrag9CxyevDW
